### PR TITLE
Update build_repository.yaml

### DIFF
--- a/.github/workflows/build_repository.yaml
+++ b/.github/workflows/build_repository.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - name: Get current time and date
       id: date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%d %H:%M')"
+      run: echo "date=$(date +'%Y-%m-%d %H:%M')" >> $GITHUB_OUTPUT
 
     - name: Build Packages
       uses: kopp/build-aur-packages@v1


### PR DESCRIPTION
Updated set-output to use the new GITHUB_STATE variable as set-output has been deprecated